### PR TITLE
[feat] Add `index.html` rewrite support for S3 directories, `.../`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:bionic
 
 ENV NGINX_VERSION=1.17.4
+ENV INDEX_FILE="index.html"
 ENV CACHE_NAME="edge-cache"
 ENV CACHE_SIZE="1g"
 ENV CACHE_INACTIVE="1d"

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,6 @@ WORKDIR /etc/nginx
 
 EXPOSE 80
 EXPOSE 443
+EXPOSE 48480
 
 CMD /bin/bash /run.sh

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Several options are customizable using environment variables.
 * ``AWS_ACCESS_KEY``: The Access Key that gives access to your S3 Bucket.
 * ``AWS_SECRET_KEY``: The Secret Key that gives access to your S3 Bucket.
 * ``AWS_REGION``: The Region that your bucket is hosted at.
+* ``INDEX_FILE``: Set default index filename to rewrite requests for directories, paths ending with ``/``.  Defaults to ``index.html``.
 * ``AMPLIFY_API_KEY``: If you want your container monitored by Amplify, add your API key. Might be a good idea to set a hostname on the container.
 * ``SERVER_NAME``: Set a server name if you want to have a unique name set in your Nginx config.
 * ``CACHE_PATH``: Set a path for a cache folder if you wan't to enable the caching for Nginx.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Several options are customizable using environment variables.
 * ``AWS_REGION``: The Region that your bucket is hosted at.
 * ``INDEX_FILE``: Set default index filename to rewrite requests for directories, paths ending with ``/``.  Defaults to ``index.html``.
 * ``AMPLIFY_API_KEY``: If you want your container monitored by Amplify, add your API key. Might be a good idea to set a hostname on the container.
-* ``SERVER_NAME``: Set a server name if you want to have a unique name set in your Nginx config.
+* ``SERVER_NAME``: Set a server name if you want to have a unique name set in your Nginx config.  If set, nginx will listen on both port ``80`` and ``48480``, the latter so it's unlikely to conflict.
 * ``CACHE_PATH``: Set a path for a cache folder if you wan't to enable the caching for Nginx.
 * ``CACHE_NAME``: If you want a unique name for your cache (in cacse of multiple). Defaults to ``edge-cache``.
 * ``CACHE_SIZE``: Set a max size for you cache. Defaults to ``1g``.

--- a/run.sh
+++ b/run.sh
@@ -5,10 +5,16 @@ if [[ $SERVER_NAME ]]; then
 fi
 
 if [[ $AWS_ACCESS_KEY ]] && [[ $AWS_SECRET_KEY ]] && [[ $AWS_REGION ]] && [[ $AWS_BUCKET ]]; then
+
+    if [[ $INDEX_FILE ]]; then
+        INDEX_FILE_CONFIG="        rewrite ^(.*)/$ \$1/${INDEX_FILE};"
+    fi
+
     AWS_SIGNING=$(/generate_signing_key -k ${AWS_SECRET_KEY} -r ${AWS_REGION})
     AWS_SIGNING_KEY=$(echo $AWS_SIGNING | awk '{print $1}')
     AWS_KEY_SCOPE=$(echo $AWS_SIGNING | awk '{print $2}')
-    AWS_KEY_CONFIG="aws_access_key ${AWS_ACCESS_KEY};
+    AWS_KEY_CONFIG="${INDEX_FILE_CONFIG}
+        aws_access_key ${AWS_ACCESS_KEY};
         aws_key_scope ${AWS_KEY_SCOPE};
         aws_signing_key ${AWS_SIGNING_KEY};
         aws_s3_bucket ${AWS_BUCKET};"

--- a/run.sh
+++ b/run.sh
@@ -51,6 +51,7 @@ ${CACHE_PATH_CONFIG}
 
 server {
     listen 80;
+    listen 48480;
     ${SERVER_NAME_CONFIG}
     ${AWS_KEY_CONFIG}
 


### PR DESCRIPTION
* ``INDEX_FILE``: Set default index filename to rewrite requests for directories, paths ending with ``/``.  Defaults to ``index.html``.

Works for me using the built image from my fork at
https://hub.docker.com/r/merpatterson/nginx-s3 including with `INDEX_FILE` unset,
rewrites to `index.html`, and with `INDEX_FILE=` (the empty string), doesn't rewrite.